### PR TITLE
fixing uppercase tag bug

### DIFF
--- a/src/commands/tag.ts
+++ b/src/commands/tag.ts
@@ -19,12 +19,12 @@ export default class TagCommand extends Command {
 	}
 
 	async add(message: KlasaMessage, [tag, content]: [string, string]) {
-		await message.guild.settings.update('tags', [...message.guild.settings.get('tags') as Tag[], [tag, content]], { action: 'overwrite' });
+		await message.guild.settings.update('tags', [...message.guild.settings.get('tags') as Tag[], [tag.toLowerCase(), content]], { action: 'overwrite' });
 		return message.send(`Added the tag \`${tag}\` with content: \`\`\`${Util.escapeMarkdown(content)}\`\`\``);
 	}
 
 	async remove(message: KlasaMessage, [tag]: [string]) {
-		const filtered = (message.guild.settings.get('tags') as Tag[]).filter(([name]) => name !== tag);
+		const filtered = (message.guild.settings.get('tags') as Tag[]).filter(([name]) => name !== tag.toLowerCase());
 		await message.guild.settings.update('tags', filtered, { action: 'overwrite' });
 		return message.send(`Removed the tag \`${tag}\``);
 	}
@@ -34,13 +34,13 @@ export default class TagCommand extends Command {
 	}
 
 	show(message: KlasaMessage, [tag]: [string]) {
-		const emote = (message.guild.settings.get('tags') as Tag[]).find(([name]) => name === tag);
+		const emote = (message.guild.settings.get('tags') as Tag[]).find(([name]) => name === tag.toLowerCase());
 		if (!emote) return null;
 		return message.send(emote[1]);
 	}
 
 	source(message: KlasaMessage, [tag]: [string]) {
-		const emote = (message.guild.settings.get('tags') as Tag[]).find(([name]) => name === tag);
+		const emote = (message.guild.settings.get('tags') as Tag[]).find(([name]) => name === tag.toLowerCase());
 		if (!emote) return null;
 		return message.send(`\`\`\`${Util.escapeMarkdown(emote[1])}\`\`\``);
 	}


### PR DESCRIPTION
### Description of the PR
This fixes a bug that was found earlier in that, if a tag is created with an uppercase character, it will never be found unless the `tag show` command is used directly

Example:
```
tag add Hello World
```

```
[p]Hello - this will fail
```

```
[p]tag show Hello - this is the only way to view them
```

This is due to the way Klasa passes the attempted command in the commandUnknown event

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixes a few minor caps bugs

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
